### PR TITLE
add telegram group for Berlin meetups to map (meetup.json)

### DIFF
--- a/content/meetups.json
+++ b/content/meetups.json
@@ -21,6 +21,13 @@
     "left": 65
   },
   {
+    "name": "Einundzwanzig Berlin",
+    "region": "Berlin",
+    "url": "https://t.me/joinchat/vUYgAbXeCnIzMWRi",
+    "top": 27,
+    "left": 65
+  },
+  {
     "name": "Einundzwanzig Düsseldorf",
     "region": "Düsseldorf",
     "url": "https://t.me/joinchat/pwUMGpOQzDZiZDRi",


### PR DESCRIPTION
Neben der [Bitcoin Lab Meetup Gruppe](https://www.meetup.com/Bitcoin-Lab-Berlin/) gibt es auch eine Telegram Meetup Gruppe seit kurzem. Bitte hinzufügen, damit das mehr Leute finden