### PR TITLE
Update meetups.json

### DIFF
--- a/content/meetups.json
+++ b/content/meetups.json
@@ -163,9 +163,16 @@
   {
     "name": "Bitcoin Graz",
     "region": "Graz",
-    "url": "https://www.meetup.com/de-DE/Bitcoin-Austria/events/279372582/",
+    "url": "https://www.meetup.com/de-DE/Bitcoin-Austria/",
     "top": 83,
     "left": 87
+  },
+  {
+    "name": "Einundzwanzig Innsbruck",
+    "region": "Innsbruck",
+    "url": "https://t.me/joinchat/tEUQAr-3-m8xNWVk",
+    "top": 82,
+    "left": 51
   },
   {
     "name": "Bitcoin Bern",


### PR DESCRIPTION
*) Bitcoin Graz-Link neu auf Event-Übersichtsseite statt direkt auf den vergangenen Termin
*) Neues Meetup: Einundzwanzing Innsbruck    (gemeinsam mit Bitcoin Austria)