### PR TITLE
Add meetup country and state or kanton

### DIFF
--- a/content/meetups.json
+++ b/content/meetups.json
@@ -1,7 +1,6 @@
 [
   {
     "name": "Einundzwanzig Mecklenburg-Vorpommern",
-    "region": "Rostock, Stralsund, Greifswald",
     "url": "https://t.me/joinchat/lMbna3mlZXc0NmZi",
     "top": 11,
     "left": 59,
@@ -10,7 +9,6 @@
   },
   {
     "name": "Einundzwanzig Norddeutschland",
-    "region": "Hamburg, Bremen, Hannover",
     "url": "https://t.me/joinchat/k4sCySBhUx03NzFi",
     "top": 18,
     "left": 36,
@@ -19,7 +17,6 @@
   },
   {
     "name": "Bitcoin Berlin",
-    "region": "Berlin",
     "url": "https://www.meetup.com/de-DE/Bitcoin-Lab-Berlin/",
     "top": 25,
     "left": 65,
@@ -28,7 +25,6 @@
   },
   {
     "name": "Einundzwanzig Berlin",
-    "region": "Berlin",
     "url": "https://t.me/joinchat/vUYgAbXeCnIzMWRi",
     "top": 27,
     "left": 65,
@@ -37,7 +33,6 @@
   },
   {
     "name": "Einundzwanzig Osnabrück",
-    "region": "Osnabrück",
     "url": "https://t.me/joinchat/Fw8Q8DQgishiNjEy",
     "top": 28,
     "left": 27,
@@ -46,7 +41,6 @@
   },
   {
     "name": "Einundzwanzig Essen",
-    "region": "Essen, Mühlheim",
     "url": "https://t.me/Einundzwanzig_Ruhrgebiet",
     "top": 35,
     "left": 20,
@@ -55,7 +49,6 @@
   },
   {
     "name": "Einundzwanzig Düsseldorf",
-    "region": "Düsseldorf",
     "url": "https://t.me/joinchat/pwUMGpOQzDZiZDRi",
     "top": 38,
     "left": 16,
@@ -64,7 +57,6 @@
   },
   {
     "name": "Einundzwanzig Heinsberg",
-    "region": "Heinsberg",
     "url": "https://t.me/joinchat/u4n4Im4IrSdjYTMy",
     "top": 40,
     "left": 9,
@@ -73,7 +65,6 @@
   },
   {
     "name": "Einundzwanzig OWL",
-    "region": "Ostwestfalen",
     "url": "https://t.me/joinchat/xypeWtlKm1JjN2I0",
     "top": 31,
     "left": 24,
@@ -82,7 +73,6 @@
   },
   {
     "name": "Einundzwanzig Sachsen-Anhalt",
-    "region": "Sachsen-Anhalt",
     "url": "https://t.me/Meetup21SA",
     "top": 31,
     "left": 53,
@@ -91,7 +81,6 @@
   },
   {
     "name": "Einundzwanzig Göttingen",
-    "region": "Göttingen",
     "url": "https://t.me/joinchat/734j5QkMMcEyZDM6",
     "top": 34,
     "left": 41,
@@ -100,7 +89,6 @@
   },
   {
     "name": "Bitcoin Leipzig",
-    "region": "Leipzig",
     "url": "https://www.meetup.com/de-DE/Leipziger-Bitcoin-Stammtisch/",
     "top": 37,
     "left": 60,
@@ -109,7 +97,6 @@
   },
   {
     "name": "Bitcoin Dresden",
-    "region": "Dresden",
     "url": "https://www.meetup.com/de-DE/Dresdner-Bitcoin-Stammtisch",
     "top": 40,
     "left": 69,
@@ -118,7 +105,6 @@
   },
   {
     "name": "Einundzwanzig Köln",
-    "region": "Köln",
     "url": "https://t.me/joinchat/0rUVc-k5fBljNWUy",
     "top": 42,
     "left": 17,
@@ -127,7 +113,6 @@
   },
   {
     "name": "Einundzwanzig Frankfurt am Main",
-    "region": "Frankfurt am Main",
     "url": "https://t.me/joinchat/Ox2zR68PzuQ2OTYy",
     "top": 51,
     "left": 26,
@@ -136,7 +121,6 @@
   },
   {
     "name": "Einundzwanzig Mainz",
-    "region": "Mainz, Wiesbaden",
     "url": "https://t.me/joinchat/kgdKrjL58C1lOTAy",
     "top": 55,
     "left": 24,
@@ -145,7 +129,6 @@
   },
   {
     "name": "Einundzwanzig Mannheim",
-    "region": "Rhein-Neckar",
     "url": "https://t.me/joinchat/lYrIAlEAZYwzNThi",
     "top": 58,
     "left": 25,
@@ -154,7 +137,6 @@
   },
   {
     "name": "Einundzwanzig Saarland",
-    "region": "Saarland",
     "url": "https://t.me/einundzwanzigsaarland",
     "top": 58,
     "left": 13,
@@ -163,7 +145,6 @@
   },
   {
     "name": "Einundzwanzig Franken",
-    "region": "Franken",
     "url": "https://t.me/joinchat/08upA6MrVKpkNWE6",
     "top": 59,
     "left": 52,
@@ -172,7 +153,6 @@
   },
   {
     "name": "Einundzwanzig Stuttgart",
-    "region": "Stuttgart",
     "url": "https://t.me/joinchat/JdWiqM3tYh4wZTMy",
     "top": 66,
     "left": 30,
@@ -181,7 +161,6 @@
   },
   {
     "name": "Einundzwanzig Passau",
-    "region": "Niederbayern",
     "url": "https://t.me/joinchat/4f7oq2Phj9hmMmEy",
     "top": 67,
     "left": 68,
@@ -190,7 +169,6 @@
   },
   {
     "name": "Einundzwanzig Augsburg",
-    "region": "Augsburg",
     "url": "https://t.me/joinchat/Jn-S3Nf2rcE1YjMy",
     "top": 70,
     "left": 46,
@@ -199,7 +177,6 @@
   },
   {
     "name": "Bitcoin Ulm",
-    "region": "Ulm",
     "url": "https://www.meetup.com/de-DE/Bitcoin-Ulm/",
     "top": 70,
     "left": 38,
@@ -208,7 +185,6 @@
   },
   {
     "name": "Bitcoin München",
-    "region": "München",
     "url": "https://www.meetup.com/de-DE/Bitcoin-Munich/",
     "top": 72,
     "left": 53,
@@ -217,7 +193,6 @@
   },
   {
     "name": "Einundzwanzig Freiburg",
-    "region": "Freiburg im Breisgau",
     "url": "https://t.me/joinchat/YLGPVwmdHY0zZWNi",
     "top": 73,
     "left": 21,
@@ -226,7 +201,6 @@
   },
   {
     "name": "Einundzwanzig Kempten",
-    "region": "Allgäu",
     "url": "https://t.me/joinchat/e1KRNLcIeto3MDky",
     "top": 77,
     "left": 41,
@@ -235,7 +209,6 @@
   },
   {
     "name": "Einundzwanzig Wien",
-    "region": "Wien",
     "url": "https://t.me/joinchat/zrBSbkocvlUyZWE8",
     "top": 70,
     "left": 93,
@@ -244,7 +217,6 @@
   },
   {
     "name": "Einundzwanzig Ried i.I.",
-    "region": "Ried im Innkreis",
     "url": "https://t.me/joinchat/ilNlHsXTLqsyOTA0",
     "top": 70,
     "left": 69,
@@ -253,7 +225,6 @@
   },
   {
     "name": "Einundzwanzig Salzburg",
-    "region": "Salzburg",
     "url": "https://t.me/BitcoinSalzburg",
     "top": 76,
     "left": 66,
@@ -262,7 +233,6 @@
   },
   {
     "name": "Einundzwanzig Innsbruck",
-    "region": "Innsbruck",
     "url": "https://t.me/joinchat/tEUQAr-3-m8xNWVk",
     "top": 82,
     "left": 51,
@@ -271,7 +241,6 @@
   },
   {
     "name": "Bitcoin Graz",
-    "region": "Graz",
     "url": "https://www.meetup.com/de-DE/Bitcoin-Austria/",
     "top": 83,
     "left": 87,
@@ -280,7 +249,6 @@
   },
   {
     "name": "Bitcoin Bern",
-    "region": "Bern, Schweiz",
     "url": "https://www.meetup.com/de-DE/bitcoin-bern/events/",
     "top": 85,
     "left": 17,
@@ -289,7 +257,6 @@
   },
   {
     "name": "Bitcoin Zürich",
-    "region": "Zürich, Schweiz",
     "url": "https://www.meetup.com/de-DE/Bitcoin-Meetup-Switzerland/?_locale=de-DE",
     "top": 81,
     "left": 27,
@@ -298,7 +265,6 @@
   },
   {
     "name": "Einundzwanzig Schweiz",
-    "region": "Schweiz",
     "url": "https://t.me/joinchat/8-FBDoq3Y9hkODZk",
     "top": 87,
     "left": 23,
@@ -307,7 +273,6 @@
   },
   {
     "name": "Einundzwanzig Liechtenstein",
-    "region": "Liechtenstein",
     "url": "https://t.me/joinchat/0UnzuwPmiitlMzE0",
     "top": 84,
     "left": 35,


### PR DESCRIPTION
This is useful because we can now group the meetups better in the smartphone view and using the Telegram Bot.