### PR TITLE
Change Basel Meetup link

### DIFF
--- a/content/meetups.json
+++ b/content/meetups.json
@@ -354,7 +354,7 @@
   },
   {
     "name": "Einundzwanzig Basel",
-    "url": "https://t.me/einundzwanzig_basel",
+    "url": "https://t.me/+WXOsBh5Y-yU4ZGY0",
     "top": 80,
     "left": 19,
     "country": "CH",


### PR DESCRIPTION
The current link points to channel which is not practical. New link points to active  "Einundzwanzig Basel" Group which is referenced in channel.