### PR TITLE
Add MIT License

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-2022 Verein Einundzwanzig
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "einundzwanzig.space",
       "version": "0.1.0",
-      "license": "UNLICENSED",
+      "license": "MIT",
       "dependencies": {
         "amplitudejs": "5.3.2"
       },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "name": "einundzwanzig.space",
   "description": "Einundzwanzig Podcast Website",
   "repository": "git@github.com:Einundzwanzig-Podcast/einundzwanzig.space.git",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "engines": {
     "node": ">=16.0.0"
   },


### PR DESCRIPTION
I think we should add a LICENSE to the website since currently the project is unlicensed and could therefore not "legally" be used anywhere else.

This also makes it easier for other "forks" of the Einundzwanzig club to fork the website and use it to host their own content.