### PR TITLE
Blockreport Channel aus dem Verzeichnis entfernen

### DIFF
--- a/content/telegram.json
+++ b/content/telegram.json
@@ -26,9 +26,5 @@
   {
     "name": "3D-Druck",
     "url": "https://t.me/einundzwanzig_3D"
-  },
-  {
-    "name": "Blockreport",
-    "url": "https://t.me/BlockReportDisc"
   }
 ]


### PR DESCRIPTION
Weder der Kanal, noch der Bot, werder derzeit aktiv maintained.