### PR TITLE
Änderung Bezeichnung des Meetups Kaiserslautern

### DIFF
--- a/content/meetups.json
+++ b/content/meetups.json
@@ -248,8 +248,8 @@
     "state": ["Saarland"]
   },
   {
-    "name": "Einundzwanzig Kaiserslautern",
-    "url": "https://t.me/einundzwanzigKL",
+    "name": "Einundzwanzig Pfalz",
+    "url": "https://t.me/einundzwanzigPfalz",
     "top": 59,
     "left": 19,
     "country": "DE",


### PR DESCRIPTION
Wir haben per Abstimmung entschieden unser Meetup auf die Pfalz auszuweiten. 
Koordinaten müssten noch passen, da Kaiserslautern relativ zentral in der Pfalz gelegen ist.

Grüße! 