### PR TITLE
Update meetups.json

### DIFF
--- a/content/meetups.json
+++ b/content/meetups.json
@@ -88,6 +88,14 @@
     "state": ["Berlin"]
   },
   {
+    "name": "Einundzwanzig Potsdam",
+    "url": "https://t.me/Einundzwanzig_Potsd",
+    "top": 25,
+    "left": 64,
+    "country": "DE",
+    "state": ["Brandenburg"]
+  },
+  {
     "name": "Bitcoin Hannover",
     "url": "https://t.me/joinchat/CE-3VDEiVBVmMjNi",
     "top": 27,


### PR DESCRIPTION
Added Einundzwanzig Potsdam. Telegram-Link ("https://t.me/Einundzwanzig_Potsdam") was too long for being accepted. Now it's just "https://t.me/Einundzwanzig_Potsd"