### PR TITLE
Shopänderung

### DIFF
--- a/content/shops.json
+++ b/content/shops.json
@@ -4,8 +4,8 @@
     "url": "https://copiaro.de/einundzwanzig"
   },
   {
-    "name": "Bahibo (T-Shirts, Hoodies, Whitepaper)",
-    "url": "https://bahibo.com/"
+    "name": "Whitepapers",
+    "url": "http://whitepapershop.net/"
   },
   {
     "name": "Dezentralshop (T-Shirts, Sticker, Bücher (🇨🇭Schweiz)",


### PR DESCRIPTION
Bahibo.com existiert nicht mehr. Neu Seite: whitepapershop.net