### PR TITLE
Add cross-env to npm start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "episodes": "npm run fetch && mkdir -p episodes && node tasks/fetch_episodes.js",
     "copy": "cp -rT static dist && cp node_modules/amplitudejs/dist/amplitude.min.js dist/js/player.js",
     "init": "npm-run-all clean copy -p fetch build:data",
-    "start": "NODE_ENV=development npm-run-all init -p start:*",
+    "start": "cross-env NODE_ENV=development npm-run-all init -p start:*",
     "start:data": "onchange -k 'content/**/*' 'tasks/generate_site_data.js' -- npm run build:data",
     "start:pages": "onchange -i -k 'pug.config.js' 'markdown.js' 'content/**' 'generated/**' 'src/**/*.pug' 'src/**/*.svg' 'tasks/generate_pages.js' -- npm run build:pages",
     "start:styles": "onchange -i -k 'src/**/*.css' -- npm run build:styles",
@@ -41,6 +41,7 @@
   "devDependencies": {
     "autoprefixer": "10.4.13",
     "browser-sync": "2.27.12",
+    "cross-env": "^7.0.3",
     "csso-cli": "4.0.1",
     "fast-xml-parser": "4.1.2",
     "glob": "8.1.0",


### PR DESCRIPTION
I tried to run this on Windows, but I had to change the npm start script to get it working.