### PR TITLE
Add BitBanana to donations page

### DIFF
--- a/content/spendenregister/bitbanana.json
+++ b/content/spendenregister/bitbanana.json
@@ -1,0 +1,8 @@
+{
+  "name": "BitBanana",
+  "github": "michaelWuensch/BitBanana",
+  "twitter": "BitBananaApp",
+  "spendenURL": "https://bitbanana.app/donate",
+  "avatar": "https://bitbanana.app/favicon.svg",
+  "beschreibung": "BitBanana ist eine Android App, die es erlaubt, Lightning Nodes vom Smartphone aus zu managen. Außerdem kann man so mit seiner eigenen Node auch Zahlungen tätigen, ganz so, als ob es eine mobile Wallet wäre. Die App wird von einem deutschen Entwickler programmiert und ist deshalb auch immer vollständig auf Deutsch verfügbar."
+}


### PR DESCRIPTION
Hi,
dieser PR fügt BitBanana dem Spendenregister hinzu.
BitBanana wurde bereits mit 1.000.000 sats von Einundzwanzig unterstützt, trotzdem habe ich es mal nicht bei der SpendenÜbersicht hinzugefügt. Falls das auch gewünscht ist, könnt ihr es entweder gerne selber machen, oder mir hier bescheid geben, dann kann ich dafür einen weiteren PR machen.